### PR TITLE
fix: add environment check to web-router script injection

### DIFF
--- a/.changeset/fix-web-router-env-check.md
+++ b/.changeset/fix-web-router-env-check.md
@@ -1,0 +1,5 @@
+---
+'@web-widget/flags-kit': patch
+---
+
+Fix web-router environment check to only inject flag values script tags in Vercel environments, matching Next.js/SvelteKit behavior.

--- a/packages/flags/src/web-router/html-transform.test.ts
+++ b/packages/flags/src/web-router/html-transform.test.ts
@@ -1,7 +1,20 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createFlagScriptInjectionTransform } from './html-transform';
 
+// Mock process.env for testing
+const originalEnv = process.env;
+
 describe('createFlagScriptInjectionTransform', () => {
+  beforeEach(() => {
+    // Reset environment variables before each test
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    // Restore original environment variables
+    process.env = originalEnv;
+  });
+
   it('should inject script before </body> tag', async () => {
     const html = '<html><body><h1>Hello</h1></body></html>';
     const scriptContent = async () => '{"flag1":true}';
@@ -60,8 +73,35 @@ describe('createFlagScriptInjectionTransform', () => {
     );
   });
 
-  it('should not inject when no </body> tag', async () => {
-    const html = '<html><body><h1>Hello</h1></html>';
+  it('should handle empty script content', async () => {
+    const html = '<html><body><h1>Hello</h1></body></html>';
+    const scriptContent = async () => '';
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(html));
+        controller.close();
+      },
+    });
+
+    const transform = createFlagScriptInjectionTransform(scriptContent);
+    const transformedStream = stream.pipeThrough(transform);
+
+    const reader = transformedStream.getReader();
+    let result = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      result += new TextDecoder().decode(value);
+    }
+
+    // Should not inject script tag when content is empty
+    expect(result).toBe('<html><body><h1>Hello</h1></body></html>');
+  });
+
+  it('should handle HTML without body tag', async () => {
+    const html = '<html><head><title>Test</title></head></html>';
     const scriptContent = async () => '{"flag3":true}';
 
     const stream = new ReadableStream({
@@ -83,6 +123,7 @@ describe('createFlagScriptInjectionTransform', () => {
       result += new TextDecoder().decode(value);
     }
 
-    expect(result).toBe(html);
+    // Should not inject script tag when there's no body tag
+    expect(result).toBe('<html><head><title>Test</title></head></html>');
   });
 });


### PR DESCRIPTION
- Add isVercelEnvironment() function to detect Vercel deployment
- Conditionally inject script tags only in Vercel environments
- Match behavior of Next.js and SvelteKit frameworks
- Ensure consistency across all frameworks in the flags package